### PR TITLE
Added end time functionality to the event items

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -13,5 +13,5 @@ class EventAdmin(admin.ModelAdmin):
 
 @admin.register(TimeTable)
 class TimeTableAdmin(admin.ModelAdmin):
-    list_display = ('item_event', 'start_time', 'created', 'description')
-    list_filter = ('item_event', 'start_time', 'created')
+    list_display = ('item_event', 'start_time', 'end_time', 'created', 'description')
+    list_filter = ('item_event', 'start_time', 'end_time', 'created')

--- a/models.py
+++ b/models.py
@@ -24,7 +24,8 @@ class Event(models.Model):
         return self.name
 class TimeTable(models.Model):
     item_event = models.ForeignKey(Event, on_delete=models.CASCADE, related_name='items', verbose_name="Event Name")
-    start_time = models.TimeField(verbose_name="Time", help_text="When this will start")
+    start_time = models.TimeField(verbose_name="Start Time", help_text="When this will start")
+    end_time = models.TimeField(verbose_name="End Time", help_text="When this will end", blank=True, null=True)
     created = models.DateTimeField(auto_now_add=True)
     description = models.TextField(verbose_name="Event Description", help_text="Event activity/description what will happen at this time")
 

--- a/templates/django_events_timetable/event_items.html
+++ b/templates/django_events_timetable/event_items.html
@@ -17,7 +17,12 @@
             {% for item in items %}
             <div class="dj_timetable_event_item">
                 <div class="dj_timetable_ei_Dot dj_timetable_dot_active"></div>
-                <div class="dj_timetable_ei_Title">{{ item.start_time|date:"g:i A" }}</div>
+                <div class="dj_timetable_ei_Title">{{ item.start_time|date:"g:i A" }}
+                    {% if item.end_time %}
+                        - {{ item.end_time|date:"g:i A" }}
+                    {% endif %}
+
+                </div>
                 <div class="dj_timetable_ei_Copy">{{ item.description }}</div>
             </div>
             {% endfor %}


### PR DESCRIPTION
Fixed #28 

The following are the enhancements done:
- [x] Add the new field to the TimeTable model that can hold the end date of the event item
- [x] This new field should not be mandatory
- [x] If this newly added field is present, then it will be displayed on the UI else no end time for the event will be displayed
- [x] Changes need to be made in the admin.py file for showing and filtering the newly added field