### PR TITLE
Added title field in the TimeTable model

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -13,5 +13,5 @@ class EventAdmin(admin.ModelAdmin):
 
 @admin.register(TimeTable)
 class TimeTableAdmin(admin.ModelAdmin):
-    list_display = ('item_event', 'start_time', 'end_time', 'created', 'description')
-    list_filter = ('item_event', 'start_time', 'end_time', 'created')
+    list_display = ('item_event', 'start_time', 'end_time', 'created', 'title', 'description')
+    list_filter = ('item_event', 'start_time', 'end_time', 'created', 'title')

--- a/models.py
+++ b/models.py
@@ -27,7 +27,8 @@ class TimeTable(models.Model):
     start_time = models.TimeField(verbose_name="Start Time", help_text="When this will start")
     end_time = models.TimeField(verbose_name="End Time", help_text="When this will end", blank=True, null=True)
     created = models.DateTimeField(auto_now_add=True)
-    description = models.TextField(verbose_name="Event Description", help_text="Event activity/description what will happen at this time")
+    title =models.CharField(max_length=70, verbose_name="Item Title", help_text="Event item title.")
+    description = models.TextField(verbose_name="Item Description", help_text="Event item description.", blank=True, null=True)
 
     def __str__(self):
         return f"{self.start_time} - {self.description}"

--- a/templates/django_events_timetable/event_items.html
+++ b/templates/django_events_timetable/event_items.html
@@ -15,7 +15,7 @@
             <p class="dj_timetable_ce_title">This Event <span class="dj_timetable_agenda_badge">Passed!</span></p>
         {% endif %}        
             {% for item in items %}
-            <div class="dj_timetable_event_item">
+                        <div class="dj_timetable_event_item">
                 <div class="dj_timetable_ei_Dot dj_timetable_dot_active"></div>
                 <div class="dj_timetable_ei_Title">{{ item.start_time|date:"g:i A" }}
                     {% if item.end_time %}
@@ -23,9 +23,9 @@
                     {% endif %}
 
                 </div>
-                <div class="dj_timetable_ei_Copy">{{ item.description }}</div>
+                <div class="dj_timetable_ei_Copy">{{ item.title }}</div>
             </div>
-            {% endfor %}
+                    {% endfor %}
         </div>
     </div>
     {% else %}


### PR DESCRIPTION
Fixed #30 

A new field `title` to the `TimeTable` model for storing the event item title.
The following are the tasks performed for this enhancement:

- [x] Added new field named `title` in the `TimeTable` model
- [x] Made the `title` field mandatory
- [x] Made the `description` field optional
- [x] Updated the verbose name of the `description` field
- [x] Updated the help_text of the `description` field
- [x] Updated the admin.py file for displaying and filtering the newly added field on the admin panel
- [x] Made the required changes in the event_items.html file